### PR TITLE
Add dsaparam for DH key generation

### DIFF
--- a/openvpn/tasks/main.yml
+++ b/openvpn/tasks/main.yml
@@ -111,7 +111,7 @@
      - openvpn_client_keys.results
 
  - name: Generate Diffie-Hellman parameters (this will take a while)
-   command: openssl dhparam -out {{ openvpn_dhparam }} {{ openvpn_key_size }}
+   command: openssl dhparam -out {{ openvpn_dhparam }} {{ openvpn_key_size }} -dsaparam
             creates={{ openvpn_dhparam }}
 
  - name: Show the iptables rules


### PR DESCRIPTION
When generating 4096-bit keys the generation take a really long time cause openssl use strong primes (~16 hours)
A reasonable fix is to add -dsaparam to the key generation command, which is much faster. 
DSA parameters for DH keys are also considered secure.
